### PR TITLE
repo: Set archive-mirrors to opam.ocaml.org's cache

### DIFF
--- a/repo
+++ b/repo
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 browse: "https://opam.ocaml.org/pkg/"
 upstream: "https://github.com/ocaml/opam-repository/tree/master/"
+archive-mirrors: "https://opam.ocaml.org/cache"
 announce: [
 """
 [WARNING] opam is out-of-date. Please consider updating it (https://opam.ocaml.org/doc/Install.html)


### PR DESCRIPTION
Mirrored from upstream PR #28348: https://github.com/ocaml/opam-repository/pull/28348