### PR TITLE
New LLVM 16 release to fix Homebrew installing zstd in nonstandard location

### DIFF
--- a/packages/llvm/llvm.16.0.6+nnp+fix-homebrew/opam
+++ b/packages/llvm/llvm.16.0.6+nnp+fix-homebrew/opam
@@ -31,6 +31,6 @@ url {
     "https://github.com/alan-j-hu/llvm-dune/releases/download/v16.0.6%2Bnnp%2Bfix-homebrew/llvm-dune-full-minified-16.0.6-fix-homebrew.tar.gz"
   checksum: [
     "md5=4c242a4e6a9d76b2ca493b2f14eab3ce"
-    "sha512=cc618295f1a618fdb67b65fc65d1bc40e856ad2cb0200e43573776235dca6cab"
+    "sha512=a686da11712efb02fb56c053ce4db51320b474594e1dc8291eb26ae0e8110974daa82106c82f1764531ae36a2247fade750b7d093299ca023604a5adca9cb506"
   ]
 }

--- a/packages/llvm/llvm.16.0.6+nnp+fix-homebrew/opam
+++ b/packages/llvm/llvm.16.0.6+nnp+fix-homebrew/opam
@@ -18,6 +18,7 @@ depends: [
   "dune" {>= "2.7"}
   "ctypes" {>= "0.4"}
   "conf-llvm" {build & = "16"}
+  "conf-pkg-config"
 ]
 build: [
   ["./setup.sh" conf-llvm:config]

--- a/packages/llvm/llvm.16.0.6+nnp+fix-homebrew/opam
+++ b/packages/llvm/llvm.16.0.6+nnp+fix-homebrew/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "The OCaml bindings distributed with LLVM"
+description: "Note: LLVM should be installed first."
+maintainer: "Alan Hu <alanh@ccs.neu.edu>"
+authors: [
+  "Alan Hu <alanh@ccs.neu.edu>"
+  "Kate <kit-ty-kate@outlook.com>"
+  "Gordon Henriksen <gordonhenriksen@mac.com>"
+  "whitequark <whitequark@whitequark.org>"
+  "The LLVM team"
+]
+license: "Apache-2.0 WITH LLVM-exception"
+homepage: "http://llvm.moe"
+doc: "http://llvm.moe/ocaml"
+bug-reports: "http://llvm.org/bugs/"
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "dune" {>= "2.7"}
+  "ctypes" {>= "0.4"}
+  "conf-llvm" {build & = "16"}
+]
+build: [
+  ["./setup.sh" conf-llvm:config]
+  ["dune" "build" "--release" "-j" jobs]
+  ["rm" "%{name}%.install"]
+]
+install: ["./install.sh" prefix]
+dev-repo: "git+https://github.com/alan-j-hu/llvm-dune.git"
+url {
+  src:
+    "https://github.com/alan-j-hu/llvm-dune/releases/download/v16.0.6%2Bnnp%2Bfix-homebrew/llvm-dune-full-minified-16.0.6-fix-homebrew.tar.gz"
+  checksum: [
+    "md5=4c242a4e6a9d76b2ca493b2f14eab3ce"
+    "sha512=cc618295f1a618fdb67b65fc65d1bc40e856ad2cb0200e43573776235dca6cab"
+  ]
+}


### PR DESCRIPTION
Mirrored from upstream PR #25002: https://github.com/ocaml/opam-repository/pull/25002